### PR TITLE
Update the Latent Space Visualization notebook to help the user visualize massive datasets.

### DIFF
--- a/latent_space_visualizer.ipynb
+++ b/latent_space_visualizer.ipynb
@@ -54,7 +54,8 @@
    "outputs": [],
    "source": [
     "# Select a dataset\n",
-    "dataset_file = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_{0}_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040-copy.hdf5\".format(\"3iyf-10K\", 10000)\n"
+    "#dataset_file = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_{0}_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040-copy.hdf5\".format(\"3iyf-10K\", 10000)\n",
+    "dataset_file = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_3iyf-10K_uniform_quat_dataset-size=10000_diffraction-pattern-shape=1024x1040-test-copy.hdf5\".format(\"3iyf-10K\", 10000)\n"
    ]
   },
   {
@@ -169,7 +170,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Ensemble Principal Component Analysis (in progress)\n",
+    "### Ensemble Principal Component Analysis\n",
     "\n",
     "The first two Principal Components (PCs) are used to plot the latent variables. "
    ]
@@ -182,6 +183,30 @@
    "source": [
     "# Visualize the latent space built by Ensemble PCA\n",
     "latent_space_visualizer.visualize_latent_space(dataset_file, \"diffraction_patterns\", \"ensemble_pca\",\n",
+    "                                               latent_idx_1=1, latent_idx_2=2,\n",
+    "                                                  image_plot_image_source_location=\"slac-pswww\", \n",
+    "                                                  image_plot_slac_username=\"deebanr\", \n",
+    "                                                  image_plot_slac_dataset_name=\"3iyf-10K\",\n",
+    "                                                  image_plot_image_brightness=10.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Ensemble Principal Component Analysis using MPI (in progress)\n",
+    "\n",
+    "The first two Principal Components (PCs) are used to plot the latent variables. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the latent space built by Ensemble PCA - MPI version\n",
+    "latent_space_visualizer.visualize_latent_space(dataset_file, \"diffraction_patterns\", \"ensemble_pca_mpi\",\n",
     "                                               latent_idx_1=1, latent_idx_2=2,\n",
     "                                                  image_plot_image_source_location=\"slac-pswww\", \n",
     "                                                  image_plot_slac_username=\"deebanr\", \n",

--- a/latent_space_visualizer.ipynb
+++ b/latent_space_visualizer.ipynb
@@ -57,7 +57,18 @@
     "dataset_file = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_{0}_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040-copy.hdf5\".format(\"3iyf-10K\", 10000)\n",
     "#dataset_file = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_{0}_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040-test-copy-mask-1.hdf5\".format(\"3iyf-10K\", 10000)\n",
     "#dataset_file = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_{0}_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040-test-copy.hdf5\".format(\"3iyf-10K\", 10000)\n",
-    "#dataset_file = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_{0}_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040-test-copy-n_shuffles=1.hdf5\".format(\"3iyf-10K\", 10000)\n"
+    "#dataset_file = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_{0}_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040-test-copy-n_shuffles=1.hdf5\".format(\"3iyf-10K\", 10000)\n",
+    "# h5_3iyf_10K_mixed_hit_80 = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_3iyf-10K-mixed-hit_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040.hdf5\".format(\"3iyf-10K-mixed-hit-80\", 10000)\n",
+    "# h5_3iyf_10K_mixed_hit_90 = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_3iyf-10K-mixed-hit_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040.hdf5\".format(\"3iyf-10K-mixed-hit-90\", 10000)\n",
+    "# h5_3iyf_10K_mixed_hit_95 = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_3iyf-10K-mixed-hit_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040.hdf5\".format(\"3iyf-10K-mixed-hit-95\", 10000)\n",
+    "# h5_3iyf_10K_mixed_hit_99 = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_3iyf-10K-mixed-hit_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040.hdf5\".format(\"3iyf-10K-mixed-hit-99\", 10000)\n",
+    "\n",
+    "h5_3iyf_10K_mixed_hit_99_single_hits_labeled = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_3iyf-10K-mixed-hit_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040.hdf5\".format(\"3iyf-10K-mixed-hit-99-single-hits-labeled\", 10000)\n",
+    "h5_3iyf_10K_mixed_hit_99_single_hits_labeled_incremental_pca_latent_space = \"../{0}/dataset/incremental-pca/latent-space-projection-for-downsampled-diffraction-patterns-seen-thus-far-dataset_name={0}-downsampled_shape={2}x{3}-num_diffraction_patterns={1}-batch_size={4}-batch_number_converged={5}.hdf5\".format(\"3iyf-10K-mixed-hit-99-single-hits-labeled\", 10000, 128, 128, 100, 90)\n",
+    "\n",
+    "h5_3iyf_100K_mixed_hit_99 = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_3iyf-100K-mixed-hit_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040.hdf5\".format(\"3iyf-100K-mixed-hit-99\", 100000)\n",
+    "h5_3iyf_100K_mixed_hit_99_incremental_pca_latent_space = \"../{0}/dataset/incremental-pca/09-03-20/run-1/latent-space-projection-for-downsampled-diffraction-patterns-seen-thus-far-dataset_name={0}-downsampled_shape={2}x{3}-num_diffraction_patterns={1}-batch_size={4}-batch_number_converged={5}.hdf5\".format(\"3iyf-100K-mixed-hit-99\", 100000, 128, 128, 100, 1000)\n",
+    "h5_3iyf_100K_mixed_hit_99_elliptic_envelope_outlier_prediction_mask = \"../{0}/dataset/incremental-pca/09-03-20/run-1/elliptic-envelope-outlier-predictions-for-downsampled-diffraction-patterns-seen-thus-far-dataset_name={0}-downsampled_shape={2}x{3}-num_diffraction_patterns={1}-batch_size={4}-batch_number_converged={5}.hdf5\".format(\"3iyf-100K-mixed-hit-99\", 100000, 128, 128, 100, 1000)\n"
    ]
   },
   {
@@ -82,7 +93,39 @@
     "                                  scatter_plot_ref_vector_as_a_list = [1, 0, 0],\n",
     "                                  image_plot_image_source_location=\"slac-pswww\", \n",
     "                                  image_plot_slac_username=\"deebanr\", \n",
-    "                                  image_plot_slac_dataset_name=\"3iyf-10K\",\n",
+    "                                  image_plot_slac_dataset_name=\"3iyf-10K-mixed-hit-99\",\n",
+    "                                  image_plot_image_brightness=10.0,\n",
+    "                                  real2d_plot_particle_property=\"atomic_coordinates\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the orientations for the dataset\n",
+    "latent_space_visualizer.visualize_orientations(dataset_file, \"diffraction_patterns\",\n",
+    "                                  scatter_plot_ref_vector_as_a_list = [1, 0, 0],\n",
+    "                                  image_plot_image_source_location=\"slac-pswww\", \n",
+    "                                  image_plot_slac_username=\"deebanr\", \n",
+    "                                  image_plot_slac_dataset_name=\"3iyf-10K-mixed-hit-99\",\n",
+    "                                  image_plot_image_brightness=1000.0,\n",
+    "                                  real2d_plot_particle_property=\"atomic_coordinates\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the orientations for the dataset\n",
+    "latent_space_visualizer.visualize_orientations(h5_3iyf_100K_mixed_hit_99, \"diffraction_patterns\",\n",
+    "                                  scatter_plot_ref_vector_as_a_list = [1, 0, 0],\n",
+    "                                  image_plot_image_source_location=\"slac-pswww\", \n",
+    "                                  image_plot_slac_username=\"deebanr\", \n",
+    "                                  image_plot_slac_dataset_name=\"3iyf-100K-mixed-hit-99\",\n",
     "                                  image_plot_image_brightness=10.0,\n",
     "                                  real2d_plot_particle_property=\"atomic_coordinates\")\n"
    ]
@@ -160,12 +203,211 @@
    "outputs": [],
    "source": [
     "# Visualize the latent space built by Incremental PCA\n",
-    "latent_space_visualizer.visualize_latent_space(dataset_file, \"diffraction_patterns\", \"incremental_principal_component_analysis\",\n",
+    "latent_space_visualizer.visualize_latent_space(h5_3iyf_10K_mixed_hit_80, \"diffraction_patterns\", \"incremental_principal_component_analysis\",\n",
     "                                               latent_idx_1=1, latent_idx_2=2,\n",
     "                                                  image_plot_image_source_location=\"slac-pswww\", \n",
     "                                                  image_plot_slac_username=\"deebanr\", \n",
-    "                                                  image_plot_slac_dataset_name=\"3iyf-10K\",\n",
+    "                                                  image_plot_slac_dataset_name=\"3iyf-10K-mixed-hit-80\",\n",
     "                                                  image_plot_image_brightness=10.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the latent space built by Incremental PCA\n",
+    "latent_space_visualizer.visualize_latent_space(h5_3iyf_10K_mixed_hit_90, \"diffraction_patterns\", \"incremental_principal_component_analysis\",\n",
+    "                                               latent_idx_1=1, latent_idx_2=2,\n",
+    "                                                  image_plot_image_source_location=\"slac-pswww\", \n",
+    "                                                  image_plot_slac_username=\"deebanr\", \n",
+    "                                                  image_plot_slac_dataset_name=\"3iyf-10K-mixed-hit-90\",\n",
+    "                                                  image_plot_image_brightness=10.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the latent space built by Incremental PCA\n",
+    "latent_space_visualizer.visualize_latent_space(h5_3iyf_10K_mixed_hit_95, \"diffraction_patterns\", \"incremental_principal_component_analysis\",\n",
+    "                                               latent_idx_1=1, latent_idx_2=2,\n",
+    "                                                  image_plot_image_source_location=\"slac-pswww\", \n",
+    "                                                  image_plot_slac_username=\"deebanr\", \n",
+    "                                                  image_plot_slac_dataset_name=\"3iyf-10K-mixed-hit-95\",\n",
+    "                                                  image_plot_image_brightness=10.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the latent space built by Incremental PCA\n",
+    "latent_space_visualizer.visualize_latent_space(h5_3iyf_10K_mixed_hit_99, \"diffraction_patterns\", \"incremental_principal_component_analysis\",\n",
+    "                                               latent_idx_1=1, latent_idx_2=2,\n",
+    "                                                  image_plot_image_source_location=\"slac-pswww\", \n",
+    "                                                  image_plot_slac_username=\"deebanr\", \n",
+    "                                                  image_plot_slac_dataset_name=\"3iyf-10K-mixed-hit-99\",\n",
+    "                                                  image_plot_image_brightness=10.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the latent space built by Incremental PCA\n",
+    "latent_space_visualizer.visualize_latent_space_for_incremental_principal_component_analysis(\n",
+    "                                                h5_3iyf_10K_mixed_hit_99_single_hits_labeled, \n",
+    "                                                h5_3iyf_10K_mixed_hit_99_single_hits_labeled_incremental_pca_latent_space, \n",
+    "                                                \"diffraction_patterns\",\n",
+    "                                                  latent_idx_1=2, latent_idx_2=3,\n",
+    "                                                  scatter_plot_type = \"hexbin_colored_by_single_hit_flag\",\n",
+    "                                                  image_plot_image_source_location=\"slac-pswww\", \n",
+    "                                                  image_plot_slac_username=\"deebanr\", \n",
+    "                                                  image_plot_slac_dataset_name=\"3iyf-10K-mixed-hit-99-single-hits-labeled\",\n",
+    "                                                  image_plot_image_brightness=10.0)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the latent space built by Incremental PCA\n",
+    "latent_space_visualizer.visualize_latent_space_for_incremental_principal_component_analysis(\n",
+    "                                                h5_3iyf_10K_mixed_hit_99_single_hits_labeled, \n",
+    "                                                h5_3iyf_10K_mixed_hit_99_single_hits_labeled_incremental_pca_latent_space, \n",
+    "                                                \"diffraction_patterns\",\n",
+    "                                                  latent_idx_1=2, latent_idx_2=3,\n",
+    "                                                  scatter_plot_type = \"colored_by_single_hit_flag\",\n",
+    "                                                  image_plot_image_source_location=\"slac-pswww\", \n",
+    "                                                  image_plot_slac_username=\"deebanr\", \n",
+    "                                                  image_plot_slac_dataset_name=\"3iyf-10K-mixed-hit-99-single-hits-labeled\",\n",
+    "                                                  image_plot_image_brightness=10.0)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the latent space built by Incremental PCA\n",
+    "latent_space_visualizer.visualize_latent_space_for_incremental_principal_component_analysis(\n",
+    "                                                h5_3iyf_10K_mixed_hit_99_single_hits_labeled, \n",
+    "                                                h5_3iyf_10K_mixed_hit_99_single_hits_labeled_incremental_pca_latent_space, \n",
+    "                                                \"diffraction_patterns\",\n",
+    "                                                  latent_idx_1=2, latent_idx_2=3,\n",
+    "                                                  scatter_plot_type = \"colored_by_single_hit_flag\",\n",
+    "                                                  image_plot_image_source_location=\"slac-pswww\", \n",
+    "                                                  image_plot_slac_username=\"deebanr\", \n",
+    "                                                  image_plot_slac_dataset_name=\"3iyf-10K-mixed-hit-99-single-hits-labeled\",\n",
+    "                                                  image_plot_image_brightness=100.0)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the latent space built by Incremental PCA\n",
+    "latent_space_visualizer.visualize_latent_space_for_incremental_principal_component_analysis(\n",
+    "                                                h5_3iyf_10K_mixed_hit_99_single_hits_labeled, \n",
+    "                                                h5_3iyf_10K_mixed_hit_99_single_hits_labeled_incremental_pca_latent_space, \n",
+    "                                                \"diffraction_patterns\",\n",
+    "                                                  latent_idx_1=2, latent_idx_2=3,\n",
+    "                                                  scatter_plot_type = \"colored_by_single_hit_flag\",\n",
+    "                                                  image_plot_image_source_location=\"slac-pswww\", \n",
+    "                                                  image_plot_slac_username=\"deebanr\", \n",
+    "                                                  image_plot_slac_dataset_name=\"3iyf-10K-mixed-hit-99-single-hits-labeled\",\n",
+    "                                                  image_plot_image_brightness=1000.0)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the latent space built by Incremental PCA\n",
+    "latent_space_visualizer.visualize_latent_space_for_incremental_principal_component_analysis(\n",
+    "                                                h5_3iyf_100K_mixed_hit_99, \n",
+    "                                                h5_3iyf_100K_mixed_hit_99_incremental_pca_latent_space, \n",
+    "                                                \"diffraction_patterns\",\n",
+    "                                                  latent_idx_1=1, latent_idx_2=2,\n",
+    "                                                  scatter_plot_type = \"hexbin_colored_by_single_hit_flag\",\n",
+    "                                                  image_plot_image_source_location=\"slac-pswww\", \n",
+    "                                                  image_plot_slac_username=\"deebanr\", \n",
+    "                                                  image_plot_slac_dataset_name=\"3iyf-100K-mixed-hit-99\",\n",
+    "                                                  image_plot_image_brightness=10.0)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the latent space built by Incremental PCA\n",
+    "latent_space_visualizer.visualize_latent_space_for_incremental_principal_component_analysis(\n",
+    "                                                h5_3iyf_100K_mixed_hit_99, \n",
+    "                                                h5_3iyf_100K_mixed_hit_99_incremental_pca_latent_space, \n",
+    "                                                \"diffraction_patterns\",\n",
+    "                                                  latent_idx_1=1, latent_idx_2=2,\n",
+    "                                                  scatter_plot_type = \"hexbin_colored_by_single_hit_flag\",\n",
+    "                                                  image_plot_image_source_location=\"slac-pswww\", \n",
+    "                                                  image_plot_slac_username=\"deebanr\", \n",
+    "                                                  image_plot_slac_dataset_name=\"3iyf-100K-mixed-hit-99\",\n",
+    "                                                  image_plot_image_brightness=1000.0)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the latent space built by Incremental PCA\n",
+    "latent_space_visualizer.visualize_latent_space_for_incremental_principal_component_analysis_predicted_by_elliptic_envelope_outlier_prediction(\n",
+    "                                                h5_3iyf_100K_mixed_hit_99, \n",
+    "                                                h5_3iyf_100K_mixed_hit_99_incremental_pca_latent_space, \n",
+    "                                                h5_3iyf_100K_mixed_hit_99_elliptic_envelope_outlier_prediction_mask,\n",
+    "                                                \"diffraction_patterns\",\n",
+    "                                                  latent_idx_1=1, latent_idx_2=2,\n",
+    "                                                  scatter_plot_type = \"hexbin_colored_by_outlier_prediction_label\",\n",
+    "                                                  image_plot_image_source_location=\"slac-pswww\", \n",
+    "                                                  image_plot_slac_username=\"deebanr\", \n",
+    "                                                  image_plot_slac_dataset_name=\"3iyf-100K-mixed-hit-99\",\n",
+    "                                                  image_plot_image_brightness=10.0)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the latent space built by Incremental PCA\n",
+    "latent_space_visualizer.visualize_latent_space_for_incremental_principal_component_analysis_predicted_by_elliptic_envelope_outlier_prediction(\n",
+    "                                                h5_3iyf_100K_mixed_hit_99, \n",
+    "                                                h5_3iyf_100K_mixed_hit_99_incremental_pca_latent_space, \n",
+    "                                                h5_3iyf_100K_mixed_hit_99_elliptic_envelope_outlier_prediction_mask,\n",
+    "                                                \"diffraction_patterns\",\n",
+    "                                                  latent_idx_1=1, latent_idx_2=3,\n",
+    "                                                  scatter_plot_type = \"colored_by_outlier_prediction_label\",\n",
+    "                                                  image_plot_image_source_location=\"slac-pswww\", \n",
+    "                                                  image_plot_slac_username=\"deebanr\", \n",
+    "                                                  image_plot_slac_dataset_name=\"3iyf-100K-mixed-hit-99\",\n",
+    "                                                  image_plot_image_brightness=10.0)\n"
    ]
   },
   {

--- a/latent_space_visualizer.ipynb
+++ b/latent_space_visualizer.ipynb
@@ -54,8 +54,10 @@
    "outputs": [],
    "source": [
     "# Select a dataset\n",
-    "#dataset_file = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_{0}_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040-copy.hdf5\".format(\"3iyf-10K\", 10000)\n",
-    "dataset_file = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_3iyf-10K_uniform_quat_dataset-size=10000_diffraction-pattern-shape=1024x1040-test-copy.hdf5\".format(\"3iyf-10K\", 10000)\n"
+    "dataset_file = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_{0}_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040-copy.hdf5\".format(\"3iyf-10K\", 10000)\n",
+    "#dataset_file = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_{0}_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040-test-copy-mask-1.hdf5\".format(\"3iyf-10K\", 10000)\n",
+    "#dataset_file = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_{0}_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040-test-copy.hdf5\".format(\"3iyf-10K\", 10000)\n",
+    "#dataset_file = \"../{0}/dataset/cspi_synthetic_dataset_diffraction_patterns_{0}_uniform_quat_dataset-size={1}_diffraction-pattern-shape=1024x1040-test-copy-n_shuffles=1.hdf5\".format(\"3iyf-10K\", 10000)\n"
    ]
   },
   {
@@ -211,7 +213,8 @@
     "                                                  image_plot_image_source_location=\"slac-pswww\", \n",
     "                                                  image_plot_slac_username=\"deebanr\", \n",
     "                                                  image_plot_slac_dataset_name=\"3iyf-10K\",\n",
-    "                                                  image_plot_image_brightness=10.0)"
+    "                                                  image_plot_image_brightness=10.0,\n",
+    "                                                  scatter_plot_type=\"hexbin\")"
    ]
   },
   {

--- a/latent_space_visualizer/latent_space_visualizer.py
+++ b/latent_space_visualizer/latent_space_visualizer.py
@@ -620,6 +620,7 @@ def visualize_latent_space(
     scatter_plot_y_axis_label_text_font_size='15pt', 
     scatter_plot_color_bar_height = 400,
     scatter_plot_color_bar_width = 120,
+    scatter_plot_color_points = False,
     image_plot_image_size_scale_factor = 0.9,
     image_plot_image_brightness=1.0,
     image_plot_image_source_location=None, 
@@ -654,10 +655,11 @@ def visualize_latent_space(
         latent_variable_1 = dataset_file_handle[latent_method][:, latent_idx_1 - 1]
         latent_variable_2 = dataset_file_handle[latent_method][:, latent_idx_2 - 1] 
         
-        # Load the training set mask from the HDF5 file
-        training_set_mask_key = "training_set_mask"
-        training_set_mask = dataset_file_handle[training_set_mask_key][:].astype(np.bool)
-        
+        if scatter_plot_color_points:
+            # Load the training set mask from the HDF5 file
+            training_set_mask_key = "training_set_mask"
+            training_set_mask = dataset_file_handle[training_set_mask_key][:].astype(np.bool)
+
         # unclear on how to plot targets
         # labels = np.zeros(len(images))
 
@@ -670,19 +672,27 @@ def visualize_latent_space(
     # Scatter plot for the latent vectors
     scatter_plot = figure(width=figure_width, height=figure_height, tools="pan,wheel_zoom,box_zoom,reset")
 
-    # Color the points in the scatter plot according to the training set mask    
-    scatter_plot_colors = get_colors_from_discrete_values(training_set_mask, bokeh.palettes.Set1[3][:2])
+    if scatter_plot_color_points:
         
-    # Define the legend
-    data_point_type = np.empty((len(latent_variable_1),), dtype=np.object)
-    data_point_type[training_set_mask] = "Train"
-    data_point_type[np.invert(training_set_mask)] = "Test"
-        
-    # Data source for the scatter plot
-    scatter_plot_data_source = ColumnDataSource(data=dict(latent_variable_1=latent_variable_1, latent_variable_2=latent_variable_2, data_point_type=data_point_type, scatter_plot_colors=scatter_plot_colors))
+        # Color the points in the scatter plot according to the training set mask    
+        scatter_plot_colors = get_colors_from_discrete_values(training_set_mask, bokeh.palettes.Set1[3][:2])
 
-    # Populate the scatter plot
-    scatter_plot.circle('latent_variable_1', 'latent_variable_2', fill_color='scatter_plot_colors', source=scatter_plot_data_source, fill_alpha=0.6, legend_field="data_point_type", line_color=None)
+        # Define the legend
+        data_point_type = np.empty((len(latent_variable_1),), dtype=np.object)
+        data_point_type[training_set_mask] = "Train"
+        data_point_type[np.invert(training_set_mask)] = "Test"
+
+        # Data source for the scatter plot
+        scatter_plot_data_source = ColumnDataSource(data=dict(latent_variable_1=latent_variable_1, latent_variable_2=latent_variable_2, data_point_type=data_point_type, scatter_plot_colors=scatter_plot_colors))
+
+        # Populate the scatter plot
+        scatter_plot.circle('latent_variable_1', 'latent_variable_2', fill_color='scatter_plot_colors', source=scatter_plot_data_source, fill_alpha=0.6, legend_field="data_point_type", line_color=None)
+    else:
+        # Data source for the scatter plot
+        scatter_plot_data_source = ColumnDataSource(data=dict(latent_variable_1=latent_variable_1, latent_variable_2=latent_variable_2))
+
+        # Populate the scatter plot
+        scatter_plot.circle('latent_variable_1', 'latent_variable_2', source=scatter_plot_data_source, fill_alpha=0.6, line_color=None)
 
     # Add axis labels
     if latent_method == "principal_component_analysis":

--- a/latent_space_visualizer/latent_space_visualizer.py
+++ b/latent_space_visualizer/latent_space_visualizer.py
@@ -654,7 +654,12 @@ def visualize_latent_space(
         latent_variable_1 = dataset_file_handle[latent_method][:, latent_idx_1 - 1]
         latent_variable_2 = dataset_file_handle[latent_method][:, latent_idx_2 - 1] 
         
-        if scatter_plot_type == "colored_by_training_mask":
+        if scatter_plot_type == "hexbin_colored_by_single_hit_flag":
+            # Load the single-hit mask from the HDF5 file
+            single_hit_mask_key = "single_hit_mask"
+            single_hit_mask = dataset_file_handle[single_hit_mask_key][:].astype(np.bool)
+        
+        elif scatter_plot_type == "colored_by_training_mask":
             # Load the training set mask from the HDF5 file
             training_set_mask_key = "training_set_mask"
             training_set_mask = dataset_file_handle[training_set_mask_key][:].astype(np.bool)
@@ -684,6 +689,37 @@ def visualize_latent_space(
         # Populate the scatter plot
         #scatter_plot.circle('latent_variable_1', 'latent_variable_2', source=scatter_plot_data_source, fill_alpha=0.6, line_color=None)
         scatter_plot.circle('latent_variable_1', 'latent_variable_2', source=scatter_plot_data_source, color='white', size=0.1)
+        
+        # Display data point count for each hex tile in the hexbin scatter plot
+        scatter_plot.add_tools(HoverTool(
+            tooltips=[("count", "@c")],
+            mode="mouse", point_policy="follow_mouse", renderers=[scatter_plot_hexbin_renderer]
+        ))
+    
+    elif scatter_plot_type == "hexbin_colored_by_single_hit_flag":
+        # Color the points in the scatter plot according to the single-hit mask
+        scatter_plot_colors = get_colors_from_discrete_values(single_hit_mask, bokeh.palettes.Set1[3][:2])
+
+        # Define the legend 
+        data_point_type = np.empty((len(latent_variable_1),), dtype=np.object)
+        data_point_type[single_hit_mask] = "Single-hit"
+        data_point_type[np.invert(single_hit_mask)] = "Outlier"
+
+#         # Data source for the scatter plot
+#         scatter_plot_data_source = ColumnDataSource(data=dict(latent_variable_1=latent_variable_1, latent_variable_2=latent_variable_2, data_point_type=data_point_type, scatter_plot_colors=scatter_plot_colors))
+        
+        # Make scatter plot grid invisible
+        scatter_plot.grid.visible = False
+        
+        # Data source for the scatter plot
+        scatter_plot_data_source = ColumnDataSource(data=dict(latent_variable_1=latent_variable_1, latent_variable_2=latent_variable_2, data_point_type=data_point_type, scatter_plot_colors=scatter_plot_colors))
+
+        # Hexbin the scatter plot
+        scatter_plot_hexbin_renderer, scatter_plot_hexbin_bins = scatter_plot.hexbin(latent_variable_1, latent_variable_2, size=0.5, hover_color="pink", hover_alpha=0.8)
+
+        # Populate the scatter plot
+        #scatter_plot.circle('latent_variable_1', 'latent_variable_2', source=scatter_plot_data_source, fill_alpha=0.6, line_color=None)
+        scatter_plot.circle('latent_variable_1', 'latent_variable_2', fill_color='scatter_plot_colors', source=scatter_plot_data_source, fill_alpha=0.6, legend_field="data_point_type", line_color=None,  size=0.5)
         
         # Display data point count for each hex tile in the hexbin scatter plot
         scatter_plot.add_tools(HoverTool(
@@ -733,6 +769,445 @@ def visualize_latent_space(
         scatter_plot.yaxis.axis_label = "PC {}".format(latent_idx_2)
     else:
         raise Exception("Unrecognized latent method. Please choose from: principal_component_analysis, diffusion_map")
+    
+    # Change the axis label font size
+    scatter_plot.xaxis.axis_label_text_font_size = scatter_plot_x_axis_label_text_font_size
+    scatter_plot.yaxis.axis_label_text_font_size = scatter_plot_y_axis_label_text_font_size
+
+    # Container to display the static_images
+    div_width = int(figure_width * image_plot_image_size_scale_factor)
+    div_height = int(figure_height * image_plot_image_size_scale_factor)
+    image_plot_div = Div(width=div_width, height=div_height)
+
+    # Build the layout for plots
+    layout = row(scatter_plot, image_plot_div)
+
+    # Display the corresponding image when mouse is near a point in scatter plot
+    display_image_plot_fn = display_image_plot_using_image_source_location(image_plot_image_source_location, 
+                                                        image_plot_div, 
+                                                        latent_variable_1, 
+                                                        latent_variable_2, 
+                                                        image_plot_image_brightness, 
+                                                        image_plot_index_label_text_font_size, 
+                                                        image_plot_slac_username=image_plot_slac_username, 
+                                                        image_plot_slac_dataset_name=image_plot_slac_dataset_name, 
+                                                        dataset_file=dataset_file, 
+                                                        image_type=image_type)
+    scatter_plot.js_on_event(events.MouseMove, display_image_plot_fn)
+
+    # Display the plots
+    tic = time.time()
+    show(layout)
+    toc = time.time()
+    print("It takes {:.2f} seconds to display the plots.".format(toc-tic))
+
+def visualize_latent_space_for_incremental_principal_component_analysis(
+    dataset_file,
+    latent_space_file,
+    image_type, 
+    latent_idx_1=0, 
+    latent_idx_2=1,
+    figure_height = 450, 
+    figure_width = 450, 
+    scatter_plot_x_axis_label_text_font_size='15pt',
+    scatter_plot_y_axis_label_text_font_size='15pt', 
+    scatter_plot_color_bar_height = 400,
+    scatter_plot_color_bar_width = 120,
+    scatter_plot_type = "hexbin",
+    image_plot_image_size_scale_factor = 0.9,
+    image_plot_image_brightness=1.0,
+    image_plot_image_source_location=None, 
+    image_plot_slac_username=None,
+    image_plot_slac_dataset_name=None,
+    image_plot_index_label_text_font_size='20px'
+    ):
+    
+    """
+    Visualize the latent space from an HDF5 file
+    
+    :param dataset_file: The path to the HDF5 file, as a str
+    :param latent_space_file: The path to the HDF5 file containing the latent space built by incremental_principal_component_analysis, as a str
+    :param image_type: A key in the HDF5 file that represents the type of image, as a str
+    :param latent_method: A key in the HDF5 file that represents the latent method used to build the latent space, as a str
+    :param figure_height: height of the figure containing the plots, as an int
+    :param figure_width: width of the figure containing the plots, as an int
+    :param scatter_plot_x_axis_label_text_font_size: Font size of the x axis label for the scatter plot, as a str
+    :param scatter_plot_y_axis_label_text_font_size: Font size of the y axis label for the scatter plot, as a str
+    :param scatter_plot_color_bar_height: height of the color bar, as an int
+    :param scatter_plot_color_bar_width: width of the color bar, as an int
+    :param image_plot_image_size_scale_factor: scale the image size according to a fraction of the figure size, as a float
+    :param image_plot_image_brightness: Brightness of the image displayed in the image plot, as a float
+    :param image_plot_image_source_location: An alias for the determining where to display images from, as a str
+    :param image_plot_slac_username: A valid SLAC username, as a str
+    :param image_plot_slac_dataset_name: The name of the dataset in SLAC Compute Cluster, as a str
+    :param image_plot_index_label_text_font_size: Font size of the label for the index below the image plot, as a float
+    """
+    
+    # Load metadata from the HDF5 file
+    with h5.File(dataset_file, "r") as dataset_file_handle:        
+        if scatter_plot_type == "hexbin_colored_by_single_hit_flag" or scatter_plot_type == "colored_by_single_hit_flag":
+            # Load the single-hit mask from the HDF5 file
+            single_hit_mask_key = "single_hits_mask"
+            single_hit_mask = dataset_file_handle[single_hit_mask_key][:].astype(np.bool)
+        
+        elif scatter_plot_type == "colored_by_training_mask":
+            # Load the training set mask from the HDF5 file
+            training_set_mask_key = "training_set_mask"
+            training_set_mask = dataset_file_handle[training_set_mask_key][:].astype(np.bool)
+
+        # unclear on how to plot targets
+        # labels = np.zeros(len(images))
+   
+    # Load latent space from the HDF5 file
+    tic = time.time()
+    with h5.File(latent_space_file, "r") as latent_space_file_handle: 
+        latent_space_projection_for_downsampled_diffraction_patterns_seen_thus_far_h5_key = "latent_space_projection_for_downsampled_diffraction_patterns_seen_thus_far"
+        latent_variable_1 = latent_space_file_handle[latent_space_projection_for_downsampled_diffraction_patterns_seen_thus_far_h5_key][:, latent_idx_1 - 1]
+        latent_variable_2 = latent_space_file_handle[latent_space_projection_for_downsampled_diffraction_patterns_seen_thus_far_h5_key][:, latent_idx_2 - 1] 
+#         print(latent_variable_1)
+#         print(latent_variable_2)
+#         print(latent_variable_1.shape)
+#         print(latent_variable_2.shape)
+#         latent_variable_1 = np.random.rand(200,)
+#         latent_variable_2 = np.random.rand(200,)
+        
+    toc = time.time()
+    print("It takes {:.2f} seconds to load the {} latent vectors and metadata from the HDF5 file.".format(toc-tic, len(latent_variable_1)))
+    
+    # unclear on how to plot targets
+    # n_labels = len(np.unique(labels))
+    
+    if scatter_plot_type == "hexbin":
+        # Scatter plot for the latent vectors
+        scatter_plot = figure(match_aspect=True, width=figure_width, height=figure_height, tools="pan,wheel_zoom,box_zoom,reset")
+#         scatter_plot = figure(match_aspect=True, width=figure_width, height=figure_height, tools="pan,wheel_zoom,box_zoom,reset", background_fill_color="#440154")
+
+        # Make scatter plot grid invisible
+        scatter_plot.grid.visible = False
+        
+        # Data source for the scatter plot
+        scatter_plot_data_source = ColumnDataSource(data=dict(latent_variable_1=latent_variable_1, latent_variable_2=latent_variable_2))
+
+        # Hexbin the scatter plot
+        scatter_plot_hexbin_renderer, scatter_plot_hexbin_bins = scatter_plot.hexbin(latent_variable_1, latent_variable_2, size=0.5, hover_color="pink", hover_alpha=0.8)
+
+        # Populate the scatter plot
+        #scatter_plot.circle('latent_variable_1', 'latent_variable_2', source=scatter_plot_data_source, fill_alpha=0.6, line_color=None)
+        scatter_plot.circle('latent_variable_1', 'latent_variable_2', source=scatter_plot_data_source, color='white', size=0.1)
+        
+        # Display data point count for each hex tile in the hexbin scatter plot
+        scatter_plot.add_tools(HoverTool(
+            tooltips=[("count", "@c")],
+            mode="mouse", point_policy="follow_mouse", renderers=[scatter_plot_hexbin_renderer]
+        ))
+    
+    elif scatter_plot_type == "colored_by_single_hit_flag":
+        #
+        single_hit_idx = np.where(single_hit_mask == True)[0]
+        outlier_idx = np.where(single_hit_mask == False)[0]
+        
+        #
+        single_hit_labels = np.empty((len(latent_variable_1),), dtype=np.int)
+        single_hit_labels[single_hit_idx] = 0
+        single_hit_labels[outlier_idx] = 1
+        
+        # Scatter plot for the latent vectors
+#         scatter_plot = figure(match_aspect=True, width=figure_width, height=figure_height, tools="pan,wheel_zoom,box_zoom,reset", background_fill_color="#440154")
+        scatter_plot = figure(match_aspect=True, width=figure_width, height=figure_height, tools="pan,wheel_zoom,box_zoom,reset")
+        
+        # Color the points in the scatter plot according to the single-hit mask
+        scatter_plot_colors = get_colors_from_discrete_values(single_hit_labels, [bokeh.palettes.Set1[3][1], bokeh.palettes.Set1[3][0]])
+
+        # Define the legend 
+        data_point_type = np.empty((len(latent_variable_1),), dtype=np.object)
+        data_point_type[single_hit_idx] = "Single-hit"
+        data_point_type[outlier_idx] = "Outlier"
+
+        # Data source for the scatter plot
+#         scatter_plot_data_source = ColumnDataSource(data=dict(latent_variable_1=latent_variable_1, latent_variable_2=latent_variable_2, data_point_type=data_point_type, scatter_plot_colors=scatter_plot_colors))
+        
+        # Make scatter plot grid invisible
+        scatter_plot.grid.visible = False
+        
+        # Data source for the scatter plot
+        scatter_plot_data_source = ColumnDataSource(data=dict(latent_variable_1=latent_variable_1, latent_variable_2=latent_variable_2, data_point_type=data_point_type, scatter_plot_colors=scatter_plot_colors))
+
+        # Hexbin the scatter plot
+#         scatter_plot_hexbin_renderer, scatter_plot_hexbin_bins = scatter_plot.hexbin(latent_variable_1, latent_variable_2, size=0.5, hover_color="pink", hover_alpha=0.8)
+
+        # Populate the scatter plot
+        #scatter_plot.circle('latent_variable_1', 'latent_variable_2', source=scatter_plot_data_source, fill_alpha=0.6, line_color=None)
+        scatter_plot.circle('latent_variable_1', 'latent_variable_2', fill_color='scatter_plot_colors', source=scatter_plot_data_source, fill_alpha=0.6, line_color=None, legend_field="data_point_type", size=3.0)
+        
+#         scatter_plot.circle('latent_variable_1', 'latent_variable_2', fill_color='scatter_plot_colors', source=scatter_plot_data_source, fill_alpha=0.6, legend_field="data_point_type", line_color=None)
+        
+        # Display data point count for each hex tile in the hexbin scatter plot
+#         scatter_plot.add_tools(HoverTool(
+#             tooltips=[("count", "@c")],
+#             mode="mouse", point_policy="follow_mouse", renderers=[scatter_plot_hexbin_renderer]
+#         ))
+    
+    elif scatter_plot_type == "hexbin_colored_by_single_hit_flag":
+        # Scatter plot for the latent vectors
+#         scatter_plot = figure(match_aspect=True, width=figure_width, height=figure_height, tools="pan,wheel_zoom,box_zoom,reset", background_fill_color="#440154")
+        scatter_plot = figure(match_aspect=True, width=figure_width, height=figure_height, tools="pan,wheel_zoom,box_zoom,reset")
+        
+        # Color the points in the scatter plot according to the single-hit mask
+        scatter_plot_colors = get_colors_from_discrete_values(single_hit_mask, bokeh.palettes.Set1[3][:2])
+
+        # Define the legend 
+        data_point_type = np.empty((len(latent_variable_1),), dtype=np.object)
+        data_point_type[single_hit_mask] = "Single-hit"
+        data_point_type[np.invert(single_hit_mask)] = "Outlier"
+
+        # Data source for the scatter plot
+#         scatter_plot_data_source = ColumnDataSource(data=dict(latent_variable_1=latent_variable_1, latent_variable_2=latent_variable_2, data_point_type=data_point_type, scatter_plot_colors=scatter_plot_colors))
+        
+        # Make scatter plot grid invisible
+        scatter_plot.grid.visible = False
+        
+        # Data source for the scatter plot
+        scatter_plot_data_source = ColumnDataSource(data=dict(latent_variable_1=latent_variable_1, latent_variable_2=latent_variable_2, data_point_type=data_point_type, scatter_plot_colors=scatter_plot_colors))
+
+        # Hexbin the scatter plot
+        scatter_plot_hexbin_renderer, scatter_plot_hexbin_bins = scatter_plot.hexbin(latent_variable_1, latent_variable_2, size=0.5, hover_color="pink", hover_alpha=0.8)
+
+        # Populate the scatter plot
+        #scatter_plot.circle('latent_variable_1', 'latent_variable_2', source=scatter_plot_data_source, fill_alpha=0.6, line_color=None)
+        scatter_plot.circle('latent_variable_1', 'latent_variable_2', fill_color='scatter_plot_colors', source=scatter_plot_data_source, fill_alpha=0.6, legend_field="data_point_type", line_color=None,  size=0.5)
+        
+#         scatter_plot.circle('latent_variable_1', 'latent_variable_2', fill_color='scatter_plot_colors', source=scatter_plot_data_source, fill_alpha=0.6, legend_field="data_point_type", line_color=None)
+        
+        # Display data point count for each hex tile in the hexbin scatter plot
+        scatter_plot.add_tools(HoverTool(
+            tooltips=[("count", "@c")],
+            mode="mouse", point_policy="follow_mouse", renderers=[scatter_plot_hexbin_renderer]
+        ))
+    
+    elif scatter_plot_type == "colored_by_training_mask":
+        # Scatter plot for the latent vectors
+        scatter_plot = figure(match_aspect=True, width=figure_width, height=figure_height, tools="pan,wheel_zoom,box_zoom,reset", background_fill_color="#440154")
+        
+        # Color the points in the scatter plot according to the training set mask    
+        scatter_plot_colors = get_colors_from_discrete_values(training_set_mask, bokeh.palettes.Set1[3][:2])
+
+        # Define the legend 
+        data_point_type = np.empty((len(latent_variable_1),), dtype=np.object)
+        data_point_type[training_set_mask] = "Train"
+        data_point_type[np.invert(training_set_mask)] = "Test"
+
+        # Data source for the scatter plot
+        scatter_plot_data_source = ColumnDataSource(data=dict(latent_variable_1=latent_variable_1, latent_variable_2=latent_variable_2, data_point_type=data_point_type, scatter_plot_colors=scatter_plot_colors))
+
+        # Populate the scatter plot
+        # Adapted from: https://stackoverflow.com/questions/50083062/how-to-add-legend-inside-pythons-bokeh-circle-plot
+        scatter_plot.circle('latent_variable_1', 'latent_variable_2', fill_color='scatter_plot_colors', source=scatter_plot_data_source, fill_alpha=0.6, legend_field="data_point_type", line_color=None)
+    
+    else:
+        # Scatter plot for the latent vectors
+        scatter_plot = figure(match_aspect=True, width=figure_width, height=figure_height, tools="pan,wheel_zoom,box_zoom,reset")
+
+        # Data source for the scatter plot
+        scatter_plot_data_source = ColumnDataSource(data=dict(latent_variable_1=latent_variable_1, latent_variable_2=latent_variable_2))
+        
+        # Populate the scatter plot
+        scatter_plot.circle('latent_variable_1', 'latent_variable_2', source=scatter_plot_data_source, fill_alpha=0.6, line_color=None)        
+
+    # Add axis labels
+    scatter_plot.xaxis.axis_label = "PC {}".format(latent_idx_1)
+    scatter_plot.yaxis.axis_label = "PC {}".format(latent_idx_2)
+    
+    # Change the axis label font size
+    scatter_plot.xaxis.axis_label_text_font_size = scatter_plot_x_axis_label_text_font_size
+    scatter_plot.yaxis.axis_label_text_font_size = scatter_plot_y_axis_label_text_font_size
+
+    # Container to display the static_images
+    div_width = int(figure_width * image_plot_image_size_scale_factor)
+    div_height = int(figure_height * image_plot_image_size_scale_factor)
+    image_plot_div = Div(width=div_width, height=div_height)
+
+    # Build the layout for plots
+    layout = row(scatter_plot, image_plot_div)
+
+    # Display the corresponding image when mouse is near a point in scatter plot
+    display_image_plot_fn = display_image_plot_using_image_source_location(image_plot_image_source_location, 
+                                                        image_plot_div, 
+                                                        latent_variable_1, 
+                                                        latent_variable_2, 
+                                                        image_plot_image_brightness, 
+                                                        image_plot_index_label_text_font_size, 
+                                                        image_plot_slac_username=image_plot_slac_username, 
+                                                        image_plot_slac_dataset_name=image_plot_slac_dataset_name, 
+                                                        dataset_file=dataset_file, 
+                                                        image_type=image_type)
+    scatter_plot.js_on_event(events.MouseMove, display_image_plot_fn)
+
+    # Display the plots
+    tic = time.time()
+    show(layout)
+    toc = time.time()
+    print("It takes {:.2f} seconds to display the plots.".format(toc-tic))
+
+def visualize_latent_space_for_incremental_principal_component_analysis_predicted_by_elliptic_envelope_outlier_prediction(
+    dataset_file,
+    latent_space_file,
+    outlier_prediction_mask_file,
+    image_type, 
+    latent_idx_1=0, 
+    latent_idx_2=1,
+    figure_height = 450, 
+    figure_width = 450, 
+    scatter_plot_x_axis_label_text_font_size='15pt',
+    scatter_plot_y_axis_label_text_font_size='15pt', 
+    scatter_plot_color_bar_height = 400,
+    scatter_plot_color_bar_width = 120,
+    scatter_plot_type = "hexbin",
+    image_plot_image_size_scale_factor = 0.9,
+    image_plot_image_brightness=1.0,
+    image_plot_image_source_location=None, 
+    image_plot_slac_username=None,
+    image_plot_slac_dataset_name=None,
+    image_plot_index_label_text_font_size='20px'
+    ):
+    
+    """
+    Visualize the latent space from an HDF5 file
+    
+    :param dataset_file: The path to the HDF5 file, as a str
+    :param latent_space_file: The path to the HDF5 file containing the latent space built by incremental_principal_component_analysis, as a str
+    :param outlier_prediction_mask_file: The path to the HDF5 file containing the outlier prediction mask obtained from elliptic_envelope, as a str
+    :param image_type: A key in the HDF5 file that represents the type of image, as a str
+    :param latent_method: A key in the HDF5 file that represents the latent method used to build the latent space, as a str
+    :param figure_height: height of the figure containing the plots, as an int
+    :param figure_width: width of the figure containing the plots, as an int
+    :param scatter_plot_x_axis_label_text_font_size: Font size of the x axis label for the scatter plot, as a str
+    :param scatter_plot_y_axis_label_text_font_size: Font size of the y axis label for the scatter plot, as a str
+    :param scatter_plot_color_bar_height: height of the color bar, as an int
+    :param scatter_plot_color_bar_width: width of the color bar, as an int
+    :param image_plot_image_size_scale_factor: scale the image size according to a fraction of the figure size, as a float
+    :param image_plot_image_brightness: Brightness of the image displayed in the image plot, as a float
+    :param image_plot_image_source_location: An alias for the determining where to display images from, as a str
+    :param image_plot_slac_username: A valid SLAC username, as a str
+    :param image_plot_slac_dataset_name: The name of the dataset in SLAC Compute Cluster, as a str
+    :param image_plot_index_label_text_font_size: Font size of the label for the index below the image plot, as a float
+    """
+        
+    # Load the single-hit mask from the HDF5 file
+    with h5.File(dataset_file, "r") as dataset_file_handle:        
+        if scatter_plot_type == "colored_by_outlier_prediction_label" or scatter_plot_type == "hexbin_colored_by_outlier_prediction_label":
+            # Load the single-hit mask from the HDF5 file
+            single_hit_mask_key = "single_hits_mask"
+            single_hit_mask = dataset_file_handle[single_hit_mask_key][:].astype(np.bool)
+   
+    # Load latent space from the HDF5 file
+    tic = time.time()
+    with h5.File(latent_space_file, "r") as latent_space_file_handle: 
+        latent_space_projection_for_downsampled_diffraction_patterns_seen_thus_far_h5_key = "latent_space_projection_for_downsampled_diffraction_patterns_seen_thus_far"
+        latent_variable_1 = latent_space_file_handle[latent_space_projection_for_downsampled_diffraction_patterns_seen_thus_far_h5_key][:, latent_idx_1 - 1]
+        latent_variable_2 = latent_space_file_handle[latent_space_projection_for_downsampled_diffraction_patterns_seen_thus_far_h5_key][:, latent_idx_2 - 1] 
+        
+    toc = time.time()
+    print("It takes {:.2f} seconds to load the {} latent vectors and metadata from the HDF5 file.".format(toc-tic, len(latent_variable_1)))
+    
+    # Load the outlier prediction mask from the HDF5 file
+    with h5.File(outlier_prediction_mask_file, "r") as outlier_prediction_mask_file_handle: 
+        elliptic_envelope_outlier_prediction_mask_for_downsampled_diffraction_patterns_seen_thus_far_h5_key = "elliptic_envelope_outlier_prediction_mask_for_downsampled_diffraction_patterns_seen_thus_far"
+        outlier_prediction_mask = outlier_prediction_mask_file_handle[elliptic_envelope_outlier_prediction_mask_for_downsampled_diffraction_patterns_seen_thus_far_h5_key][:]
+    
+    if scatter_plot_type == "colored_by_outlier_prediction_label":
+        
+        # Prepare the outlier prediction labels for the scatter plot colors and legend labels
+        true_positive_mask = np.bitwise_and(single_hit_mask, outlier_prediction_mask)
+        false_positive_mask = np.bitwise_and(np.bitwise_not(single_hit_mask), outlier_prediction_mask)
+        true_negative_mask = np.bitwise_and(np.bitwise_not(single_hit_mask), np.bitwise_not(outlier_prediction_mask))
+        false_negative_mask = np.bitwise_and(single_hit_mask, np.bitwise_not(outlier_prediction_mask))
+        
+        true_positive_idx = np.where(true_positive_mask == True)[0]
+        false_positive_idx = np.where(false_positive_mask == True)[0]
+        true_negative_idx = np.where(true_negative_mask == True)[0]
+        false_negative_idx = np.where(false_negative_mask == True)[0]
+        
+        # Scatter plot for the latent vectors
+        scatter_plot = figure(match_aspect=True, width=figure_width, height=figure_height, tools="pan,wheel_zoom,box_zoom,reset")
+        
+        # Color the points in the scatter plot according to the single-hit mask
+        outlier_prediction_labels = np.empty((len(latent_variable_1),), dtype=np.int)
+        outlier_prediction_labels[true_positive_idx] = 0
+        outlier_prediction_labels[false_positive_idx] = 1
+        outlier_prediction_labels[true_negative_idx] = 2
+        outlier_prediction_labels[false_negative_idx] = 3
+        
+        scatter_plot_colors = get_colors_from_discrete_values(outlier_prediction_labels, bokeh.palettes.Set1[4])
+
+        # Define the legend 
+        data_point_type = np.empty((len(latent_variable_1),), dtype=np.object)
+        data_point_type[true_positive_idx] = "True positive"        
+        data_point_type[false_positive_idx] = "False positive"
+        data_point_type[true_negative_idx] = "True negative"
+        data_point_type[false_negative_idx] = "False negative"
+
+        # Make scatter plot grid invisible
+        scatter_plot.grid.visible = False
+        
+        # Data source for the scatter plot
+        scatter_plot_data_source = ColumnDataSource(data=dict(latent_variable_1=latent_variable_1, latent_variable_2=latent_variable_2, data_point_type=data_point_type, scatter_plot_colors=scatter_plot_colors))
+
+        # Populate the scatter plot
+        scatter_plot.circle('latent_variable_1', 'latent_variable_2', fill_color='scatter_plot_colors', source=scatter_plot_data_source, fill_alpha=0.6, legend_field="data_point_type", line_color=None,  size=0.1)
+    
+    elif scatter_plot_type == "hexbin_colored_by_outlier_prediction_label":
+        
+        # Prepare the outlier prediction labels for the scatter plot colors and legend labels
+        true_positive_mask = np.bitwise_and(single_hit_mask, outlier_prediction_mask)
+        false_positive_mask = np.bitwise_and(np.bitwise_not(single_hit_mask), outlier_prediction_mask)
+        true_negative_mask = np.bitwise_and(np.bitwise_not(single_hit_mask), np.bitwise_not(outlier_prediction_mask))
+        false_negative_mask = np.bitwise_and(single_hit_mask, np.bitwise_not(outlier_prediction_mask))
+        
+        true_positive_idx = np.where(true_positive_mask == True)[0]
+        false_positive_idx = np.where(false_positive_mask == True)[0]
+        true_negative_idx = np.where(true_negative_mask == True)[0]
+        false_negative_idx = np.where(false_negative_mask == True)[0]
+        
+        # Scatter plot for the latent vectors
+        scatter_plot = figure(match_aspect=True, width=figure_width, height=figure_height, tools="pan,wheel_zoom,box_zoom,reset")
+        
+        # Color the points in the scatter plot according to the single-hit mask
+        outlier_prediction_labels = np.empty((len(latent_variable_1),), dtype=np.int)
+        outlier_prediction_labels[true_positive_idx] = 0
+        outlier_prediction_labels[false_positive_idx] = 1
+        outlier_prediction_labels[true_negative_idx] = 2
+        outlier_prediction_labels[false_negative_idx] = 3
+        
+        scatter_plot_colors = get_colors_from_discrete_values(outlier_prediction_labels, bokeh.palettes.Set1[4])
+
+        # Define the legend 
+        data_point_type = np.empty((len(latent_variable_1),), dtype=np.object)
+        data_point_type[true_positive_idx] = "True positive"        
+        data_point_type[false_positive_idx] = "False positive"
+        data_point_type[true_negative_idx] = "True negative"
+        data_point_type[false_negative_idx] = "False negative"
+
+        # Make scatter plot grid invisible
+        scatter_plot.grid.visible = False
+        
+        # Data source for the scatter plot
+        scatter_plot_data_source = ColumnDataSource(data=dict(latent_variable_1=latent_variable_1, latent_variable_2=latent_variable_2, data_point_type=data_point_type, scatter_plot_colors=scatter_plot_colors))
+
+        # Hexbin the scatter plot
+        scatter_plot_hexbin_renderer, scatter_plot_hexbin_bins = scatter_plot.hexbin(latent_variable_1, latent_variable_2, size=0.5, hover_color="pink", hover_alpha=0.8)
+
+        # Populate the scatter plot
+        scatter_plot.circle('latent_variable_1', 'latent_variable_2', fill_color='scatter_plot_colors', source=scatter_plot_data_source, fill_alpha=0.6, legend_field="data_point_type", line_color=None,  size=0.1)
+        
+        # Display data point count for each hex tile in the hexbin scatter plot
+        scatter_plot.add_tools(HoverTool(
+            tooltips=[("count", "@c")],
+            mode="mouse", point_policy="follow_mouse", renderers=[scatter_plot_hexbin_renderer]
+        ))
+
+    # Add axis labels
+    scatter_plot.xaxis.axis_label = "PC {}".format(latent_idx_1)
+    scatter_plot.yaxis.axis_label = "PC {}".format(latent_idx_2)
     
     # Change the axis label font size
     scatter_plot.xaxis.axis_label_text_font_size = scatter_plot_x_axis_label_text_font_size


### PR DESCRIPTION
Make the latent index start at one instead of zero when visualizing the latent spaces.

Read only the selected latent variables from the HDF5 file when visualizing massive latent spaces.

Visualize the latent space built by ensemble PCA using MPI. 

Add option to color scatter points according to whether the point is in the training or test set when visualizing the latent space. 

Add default option to hexbin the scatter plot for visualizing the latent space.
